### PR TITLE
Fix firmware server

### DIFF
--- a/src/artnet-firmware-server.c
+++ b/src/artnet-firmware-server.c
@@ -239,8 +239,10 @@ int server_handle_input(artnet_node n, options_t *options) {
         break;
     }
 
-    if(ent != NULL)
+    if(ent != NULL) {
+      options->uploading = 1;
       artnet_send_firmware(n, ent, options->ubea, options->buffer, options->size / sizeof(uint16_t), firmware_complete_callback, (void *) options);
+    }
 
   } else {
     printf("Invalid Command\n");
@@ -259,7 +261,7 @@ void wait_for_input(artnet_node n, options_t *options) {
   struct timeval tv;
 
   sd = artnet_get_sd(n);
-  maxsd = sd;
+  maxsd = sd + 1;
 
   while(1) {
     FD_ZERO(&rset);
@@ -289,7 +291,6 @@ void wait_for_input(artnet_node n, options_t *options) {
     }
   }
 }
-
 int main(int argc, char *argv[]) {
   artnet_node node;
   options_t options;

--- a/src/artnet-usb.c
+++ b/src/artnet-usb.c
@@ -196,8 +196,8 @@ int load_config(opts_t *ops) {
       continue ;
 
     // strip \n
-    for(c = buf ; *c != '\n' ; c++) ;
-      *c = '\0' ;
+    for(c = buf ; *c != '\n' ; c++) {};
+    *c = '\0' ;
 
     key = strtok(buf, "=") ;
     data = strtok(NULL, "=") ;


### PR DESCRIPTION
* select() never triggers when data arrives on the ArtNet socket file descriptor (select() explicitly needs max fd + 1 as first argument)
* fix artnet-usb.c compile error due to indentation on newer gcc